### PR TITLE
Upgrade vulnerable dependencies

### DIFF
--- a/graphql-spring-boot-example/pom.xml
+++ b/graphql-spring-boot-example/pom.xml
@@ -27,8 +27,8 @@
     <artifactId>graphql-spring-boot-example</artifactId>
 
     <properties>
-        <graphql-java-kickstart.version>12.0.0</graphql-java-kickstart.version>
-        <spring-boot.version>2.7.4</spring-boot.version>
+        <graphql-java-kickstart.version>15.1.0</graphql-java-kickstart.version>
+        <spring-boot.version>3.3.11</spring-boot.version>
     </properties>
 
     <dependencyManagement>
@@ -69,7 +69,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>
 
@@ -107,4 +107,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/graphql-spring-boot-example/src/main/java/bny/jpe/graphql/example/dao/ComposerRepository.java
+++ b/graphql-spring-boot-example/src/main/java/bny/jpe/graphql/example/dao/ComposerRepository.java
@@ -16,9 +16,9 @@
 
 package bny.jpe.graphql.example.dao;
 
-import javax.persistence.EntityManager;
-import javax.persistence.NoResultException;
-import javax.persistence.PersistenceContext;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.PersistenceContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/graphql-spring-boot-example/src/main/java/bny/jpe/graphql/example/entities/ComposerEntity.java
+++ b/graphql-spring-boot-example/src/main/java/bny/jpe/graphql/example/entities/ComposerEntity.java
@@ -16,14 +16,14 @@
 
 package bny.jpe.graphql.example.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;

--- a/graphql-spring-boot-example/src/main/java/bny/jpe/graphql/example/entities/CompositionEntity.java
+++ b/graphql-spring-boot-example/src/main/java/bny/jpe/graphql/example/entities/CompositionEntity.java
@@ -16,12 +16,12 @@
 
 package bny.jpe.graphql.example.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 
 import bny.jpe.graphql.kata.domain.Composition;
 import bny.jpe.graphql.kata.domain.Concerto;

--- a/graphql-spring-boot-example/src/main/java/bny/jpe/graphql/example/entities/InstrumentEntity.java
+++ b/graphql-spring-boot-example/src/main/java/bny/jpe/graphql/example/entities/InstrumentEntity.java
@@ -16,9 +16,9 @@
 
 package bny.jpe.graphql.example.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import bny.jpe.graphql.kata.domain.Instrument;
 import bny.jpe.graphql.kata.domain.InstrumentType;

--- a/graphql-spring-boot-example/src/main/java/bny/jpe/graphql/example/entities/LocationEntity.java
+++ b/graphql-spring-boot-example/src/main/java/bny/jpe/graphql/example/entities/LocationEntity.java
@@ -16,9 +16,9 @@
 
 package bny.jpe.graphql.example.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import bny.jpe.graphql.kata.domain.Location;
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,10 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <graphql-java.version>19.0</graphql-java.version>
-        <eclipse-collections.version>11.0.0</eclipse-collections.version>
-        <jackson.version>2.13.0</jackson.version>
-        <junit.version>5.8.1</junit.version>
+        <graphql-java.version>21.5</graphql-java.version>
+        <eclipse-collections.version>11.1.0</eclipse-collections.version>
+        <jackson.version>2.15.2</jackson.version>
+        <junit.version>5.10.2</junit.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- Upgraded` graphql-java`, `eclipse-collections`, `jackson`, `junit`, `graphql-java-kickstart`, and `spring-boot version` to non-vulnerable & stable versions.
- Upgraded `org.hibernate` to `org.hibernate.orm` to ensure compatibility with Spring Boot 3+ versions.
- `<parameters>true</parameters> `is added to preserve method parameter names at runtime, ensuring compatibility with Spring Boot 3+ and Spring GraphQL argument binding.
- Migration from the `old Java EE (javax.*)` namespace to the new` Jakarta EE (jakarta.*)` namespace.
